### PR TITLE
Improve SSL Labs Rating

### DIFF
--- a/roles/websauna.site/templates/nginx.conf
+++ b/roles/websauna.site/templates/nginx.conf
@@ -59,17 +59,33 @@ server {
 
     {% if ssl %}
         ssl on;
-        ssl_certificate {{nginx_ssl_certificate_path}};
+        ssl_certificate {{nginx_ssl_certificate_fullchain_path}};
         ssl_certificate_key {{nginx_ssl_certificate_path_key}};
 
         # https://wiki.mozilla.org/Security/Server_Side_TLS
         # Diffie-Hellman parameter for DHE ciphersuites, recommended 2048 bits
         # ssl_dhparam /path/to/dhparam.pem;
-        ssl_session_timeout 5m;
-        ssl_protocols SSLv3 TLSv1 TLSv1.1 TLSv1.2;
-        ssl_ciphers 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES2Ω56-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-RSA-RC4-SHA:ECDHE-ECDSA-RC4-SHA:AES128:AES256:RC4-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!3DES:!MD5:!PSK';
-        ssl_prefer_server_ciphers on;
+        
+        # most of this was generated with 
+        # https://mozilla.github.io/server-side-tls/ssl-config-generator/
+        # using these settings: Nginx, Modern, Server Version 1.10.3,
+        # OpenSSL Version 1.0.1e, HSTS Disabled
+        
+        # certs sent to the client in SERVER HELLO are concatenated in ssl_certificate
+        ssl_session_timeout 1d;
         ssl_session_cache shared:SSL:50m;
+        ssl_session_tickets off;
+        
+        # modern configuration. tweak to your needs.
+        ssl_protocols TLSv1.2;
+        ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
+        ssl_prefer_server_ciphers on;
+        
+        # OCSP Stapling ---
+        # fetch OCSP records from URL in ssl_certificate and cache them
+        ssl_stapling on;
+        ssl_stapling_verify on;
+
     {% endif %}
 
     client_max_body_size 99m;


### PR DESCRIPTION
Use the mozilla `Modern` SSL profile to raise the SSL rating to `A`