### PR TITLE
Open location for letsencrypt renewal

### DIFF
--- a/roles/websauna.site/templates/nginx.conf
+++ b/roles/websauna.site/templates/nginx.conf
@@ -85,6 +85,13 @@ server {
       deny all;
     }    
 
+    # From https://community.letsencrypt.org/t/404-on-well-known-acme-challenge/15565/10
+    # Allow letsencrypt renewal bot to access /.well-known
+    location ~ /.well-known {
+        allow all;
+	    root /var/www/html;
+    }
+
     # Finally, send all non-media requests to the Django server.
     location / {
         include uwsgi_params;


### PR DESCRIPTION
Allow letsencrypt renewal bot to access /.well-known